### PR TITLE
Fix README project description punctuation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-modern python sample project
+modern python sample project.


### PR DESCRIPTION
Add a missing period at the end of the project description in README.md.